### PR TITLE
Change the jsx callback type type to any

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -90,7 +90,7 @@
  *
  * @callback Jsx
  *   Create a production element.
- * @param {unknown} type
+ * @param {any} type
  *   Element type: `Fragment` symbol, tag name (`string`), component.
  * @param {Props} props
  *   Element props, `children`, and maybe `node`.
@@ -101,7 +101,7 @@
  *
  * @callback JsxDev
  *   Create a development element.
- * @param {unknown} type
+ * @param {any} type
  *   Element type: `Fragment` symbol, tag name (`string`), component.
  * @param {Props} props
  *   Element props, `children`, and maybe `node`.

--- a/test/index.js
+++ b/test/index.js
@@ -261,6 +261,7 @@ test('properties', async function (t) {
           }),
           {
             ...production,
+            /** @param {unknown} type */
             jsx(type, props) {
               foundProps = props
               return production.jsx(type, {})
@@ -675,6 +676,7 @@ test('react specific: `align` to `style`', async function (t) {
         renderToStaticMarkup(
           toJsxRuntime(h('td', {align: 'center'}), {
             ...production,
+            /** @param {unknown} type */
             jsx(type, props) {
               foundProps = props
               return production.jsx(type, {})
@@ -699,6 +701,7 @@ test('react specific: `align` to `style`', async function (t) {
         renderToStaticMarkup(
           toJsxRuntime(h('td', {align: 'center'}), {
             ...production,
+            /** @param {unknown} type */
             jsx(type, props) {
               foundProps = props
               return production.jsx(type, {})


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This change makes the automatic runtime of some frameworks assignable to the runtime `hast-util-to-jsx-runtime` expects.

For example, see what happens if the type of `type` is toggled in [this playground](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbwKIBsCmI0DsYF84BmUEIcA5ABYCGAzjGQFCiSyICyAJgB4BSNXAMRQQA7qgzYYACVowANHE69+AFTRcY4zDhl18REuRAdZAWgCuMYClPGupgFb9GzaPABUcWnCjmcoNEJiUjIwKDQqAGMYAHone19-TBdwN0QeAGUADX1g8jCI6MYGdRZ4GABPMECMyvQ4AF44ACU0SOgOAB46KGAsAHMFHr7+gD4AbhKuMrhK6rgAYQprDka4TKyAOi1JOAAfOGGB-bgscxQUE78ONAI+tA5J0rS5wIAFYjAaNYQGOH+4JFligOOEsAB+ABccAAglAoFQKp0litRicUSDJgC4ABtMIQMDQo79AC6RJgvWOBzOIAARmgoCdaRAIOgqFgTjscCclHwuGoNFzpLIedw+UJRELdPADhttuhtDK4LUKvUDhiODiSSczhcrlgbncsA9JrhJlMZq84AIEf1FWs-ABrLCiLBPaYvKqBPlrAAUfwBMRisy90KdLpEWDkAf+r2h7Iq0ex+K+0I+BJoSYBjrQFShhwpI31hvuHAYAEpGmi5ULzc9WFbmn4rJh0xxzNFgBAOU1ftibVQ7ZJoQOhzgsQD4tC+RP-vEaNP+Kbze0sHRCCzoU2kmg2x2rN21okW2gGEA)

```ts
import {Element} from 'hast'
import {MdxJsxFlowElementHast, MdxJsxTextElementHast} from 'mdast-util-mdx-jsx'
import * as runtime from 'preact/jsx-runtime'
import {JSX} from 'preact'

export type Style = Record<string, string>;
export type Child = JSX.Element | string | null | undefined;
export type Props = {
    children?: Array<Child> | Child;
    [prop: string]: string | number | boolean | Element | MdxJsxTextElementHast | MdxJsxFlowElementHast | JSX.Element | Style | Child[] | null | undefined;
};

export type Fragment = unknown;
export type Jsx = (
    // type: unknown,
    type: any,
    props: Props,
    key?: string | undefined
) => JSX.Element;

export type RuntimeProduction = {
    Fragment: Fragment;
    jsx: Jsx;
    jsxs: Jsx;
};

const foo: RuntimeProduction = runtime
```

`type-coverage` fails for this PR. I see 2 possible solutions:

1. Move the `Jsx` and `JsxDev` definitions into a `.d.ts` file, so we can add a `type-coverage:ignore-next-line` comment.
2. Disable `type-coverage`. Personally I don’t find it very useful anyway.

<!--do not edit: pr-->
