### PR TITLE
Refactor to use module augmentation instead of `@ts-expect-error`

### DIFF
--- a/example/create-tree.js
+++ b/example/create-tree.js
@@ -6,13 +6,7 @@
 
 /* eslint-env browser */
 
-// @ts-expect-error: TS in VS Code doesn’t seem to infer this.
-import * as hastscript from 'https://esm.sh/hastscript@8?dev'
-
-/** @type {typeof import('hastscript').h} */
-const h = hastscript.h
-/** @type {typeof import('hastscript').s} */
-const s = hastscript.s
+import {h, s} from 'https://esm.sh/hastscript@8?dev'
 
 export function createTree() {
   return h('div', [

--- a/test/index.js
+++ b/test/index.js
@@ -25,13 +25,16 @@ import {renderToStaticMarkup} from 'react-dom/server'
 // @ts-expect-error: ESM types are wrong.
 const Sval = sval.default
 
-/** @type {{Fragment: Fragment, jsx: Jsx, jsxs: Jsx}} */
-// @ts-expect-error: the react types are missing.
-const production = {Fragment: prod.Fragment, jsx: prod.jsx, jsxs: prod.jsxs}
+const production = /** @type {{Fragment: Fragment, jsx: Jsx, jsxs: Jsx}} */ ({
+  Fragment: prod.Fragment,
+  jsx: prod.jsx,
+  jsxs: prod.jsxs
+})
 
-/** @type {{Fragment: Fragment, jsxDEV: JsxDev}} */
-// @ts-expect-error: the react types are missing.
-const development = {Fragment: dev.Fragment, jsxDEV: dev.jsxDEV}
+const development = /** @type {{Fragment: Fragment, jsxDEV: JsxDev}} */ ({
+  Fragment: dev.Fragment,
+  jsxDEV: dev.jsxDEV
+})
 
 test('core', async function (t) {
   await t.test('should expose the public api', async function () {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "target": "es2022"
   },
   "exclude": ["coverage/", "node_modules/"],
-  "include": ["**/**.js", "lib/components.d.ts"]
+  "include": ["**/**.js", "lib/components.d.ts", "types.d.ts"]
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,29 @@
+// https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68600
+declare module 'react/jsx-runtime' {
+  import {ElementType, Fragment, Key, ReactElement} from 'react'
+
+  function jsx(type: ElementType, props: unknown, key?: Key): ReactElement
+
+  export {Fragment, jsx, jsx as jsxs}
+}
+
+// https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68600
+declare module 'react/jsx-dev-runtime' {
+  import {ElementType, Fragment, Key, ReactElement} from 'react'
+  import {Source} from 'hast-util-to-jsx-runtime'
+
+  function jsxDEV(
+    type: ElementType,
+    props: unknown,
+    key: Key | undefined,
+    isStatic: boolean,
+    source?: Source,
+    self?: unknown
+  ): ReactElement
+
+  export {Fragment, jsxDEV}
+}
+
+declare module 'https://esm.sh/hastscript@8?dev' {
+  export * from 'hastscript'
+}

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,3 +1,4 @@
+// To do: remove when landed in DT
 // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68600
 declare module 'react/jsx-runtime' {
   import {ElementType, Fragment, Key, ReactElement} from 'react'
@@ -7,6 +8,7 @@ declare module 'react/jsx-runtime' {
   export {Fragment, jsx, jsx as jsxs}
 }
 
+// To do: remove when landed in DT
 // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68600
 declare module 'react/jsx-dev-runtime' {
   import {ElementType, Fragment, Key, ReactElement} from 'react'
@@ -24,6 +26,7 @@ declare module 'react/jsx-dev-runtime' {
   export {Fragment, jsxDEV}
 }
 
+// Support loading hastscript from https://esm.sh
 declare module 'https://esm.sh/hastscript@8?dev' {
   export * from 'hastscript'
 }


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This removes the need for some `@ts-expect-error` comments.

<!--do not edit: pr-->
