### PR TITLE
Check whether node.children is undefined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -793,6 +793,10 @@ function createJsxElementProps(state, node) {
 function createChildren(state, node) {
   /** @type {Array<Child>} */
   const children = []
+  if (node.children === undefined) {
+    return children
+  }
+  
   let index = -1
   /** @type {Map<string, number>} */
   // Note: test this when Solid doesn’t want to merge my upcoming PR.


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [X] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [X] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [X] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [X] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [ ] If applicable, I’ve added docs and tests (**Note: I don't see where to add a test to make sure this gets caught**)

### Description of changes

A function wasn't checking that a property was defined before trying to access that property's `length` field. The function now returns the empty list if the property is undefined. 

<!--do not edit: pr-->
