### PR TITLE
Global JSX to local JSX w/ generics

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,69 @@
 /**
- * @typedef {import('./lib/components.js').Components} Components
+ * @typedef {import('./lib/components.js').Components<JsxElement, JsxElementClass, JsxIntrinsicElements>} Components
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
+ */
+
+/**
  * @typedef {import('./lib/components.js').ExtraProps} ExtraProps
+ */
+
+/**
  * @typedef {import('./lib/index.js').CreateEvaluater} CreateEvaluater
+ */
+
+/**
  * @typedef {import('./lib/index.js').ElementAttributeNameCase} ElementAttributeNameCase
+ */
+
+/**
  * @typedef {import('./lib/index.js').EvaluateExpression} EvaluateExpression
+ */
+
+/**
  * @typedef {import('./lib/index.js').EvaluateProgram} EvaluateProgram
+ */
+
+/**
  * @typedef {import('./lib/index.js').Evaluater} Evaluater
+ */
+
+/**
  * @typedef {import('./lib/index.js').Fragment} Fragment
- * @typedef {import('./lib/index.js').Jsx} Jsx
- * @typedef {import('./lib/index.js').JsxDev} JsxDev
- * @typedef {import('./lib/index.js').Options} Options
- * @typedef {import('./lib/index.js').Props} Props
+ */
+
+/**
+ * @typedef {import('./lib/index.js').Jsx<JsxElement>} Jsx
+ * @template JsxElement
+ */
+
+/**
+ * @typedef {import('./lib/index.js').JsxDev<JsxElement>} JsxDev
+ * @template JsxElement
+ */
+
+/**
+ * @typedef {import('./lib/index.js').Options<JsxElement, JsxElementClass, JsxIntrinsicElements>} Options
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
+ */
+
+/**
+ * @typedef {import('./lib/index.js').Props<JsxElement>} Props
+ * @template JsxElement
+ */
+
+/**
  * @typedef {import('./lib/index.js').Source} Source
+ */
+
+/**
  * @typedef {import('./lib/index.js').Space} Space
+ */
+
+/**
  * @typedef {import('./lib/index.js').StylePropertyNameCase} StylePropertyNameCase
  */
 

--- a/lib/components.d.ts
+++ b/lib/components.d.ts
@@ -10,9 +10,9 @@ import type {Element} from 'hast'
  * @returns
  *   Result.
  */
-export type FunctionComponent<ComponentProps> = (
+export type FunctionComponent<JsxElement, ComponentProps> = (
   props: ComponentProps
-) => JSX.Element | string | null | undefined
+) => JsxElement | string | null | undefined
 
 /**
  * Class component: given props, returns an instance.
@@ -24,22 +24,22 @@ export type FunctionComponent<ComponentProps> = (
  * @returns
  *   Instance.
  */
-export type ClassComponent<ComponentProps> = new (
+export type ClassComponent<JsxElementClass, ComponentProps> = new (
   props: ComponentProps
-) => JSX.ElementClass
+) => JsxElementClass
 
 /**
  * Function or class component.
  *
- * You can access props at `JSX.IntrinsicElements`.
- * For example, to find props for `a`, use `JSX.IntrinsicElements['a']`.
+ * You can access props at `LocalJsx.IntrinsicElements`.
+ * For example, to find props for `a`, use `LocalJsx.IntrinsicElements['a']`.
  *
  * @typeParam ComponentProps
  *   Props type.
  */
-export type Component<ComponentProps> =
-  | ClassComponent<ComponentProps>
-  | FunctionComponent<ComponentProps>
+export type Component<JsxElement, JsxElementClass, ComponentProps> =
+  | ClassComponent<JsxElementClass, ComponentProps>
+  | FunctionComponent<JsxElement, ComponentProps>
 
 /**
  * Extra fields we pass.
@@ -49,17 +49,21 @@ export type ExtraProps = {node?: Element | undefined}
 /**
  * Possible components to use.
  *
- * Each key is a tag name typed in `JSX.IntrinsicElements`.
+ * Each key is a tag name typed in `LocalJsx.IntrinsicElements`.
  * Each value is either a different tag name, or a component accepting the
  * corresponding props (and an optional `node` prop if `passNode` is on).
  *
- * You can access props at `JSX.IntrinsicElements`.
- * For example, to find props for `a`, use `JSX.IntrinsicElements['a']`.
+ * You can access props at `LocalJsx.IntrinsicElements`.
+ * For example, to find props for `a`, use `LocalJsx.IntrinsicElements['a']`.
  */
 // Note: this type has to be in `.ts` or `.d.ts`, otherwise TSC hardcodes
 // react into the `.d.ts` file.
-export type Components = {
-  [TagName in keyof JSX.IntrinsicElements]:
-    | Component<JSX.IntrinsicElements[TagName] & ExtraProps>
-    | keyof JSX.IntrinsicElements
+export type Components<JsxElement, JsxElementClass, JsxIntrinsicElements> = {
+  [TagName in keyof JsxIntrinsicElements]:
+    | Component<
+        JsxElement,
+        JsxElementClass,
+        JsxIntrinsicElements[TagName] & ExtraProps
+      >
+    | keyof JsxIntrinsicElements
 }

--- a/lib/components.d.ts
+++ b/lib/components.d.ts
@@ -31,8 +31,8 @@ export type ClassComponent<JsxElementClass, ComponentProps> = new (
 /**
  * Function or class component.
  *
- * You can access props at `LocalJsx.IntrinsicElements`.
- * For example, to find props for `a`, use `LocalJsx.IntrinsicElements['a']`.
+ * You can access props at `JsxIntrinsicElements`.
+ * For example, to find props for `a`, use `JsxIntrinsicElements['a']`.
  *
  * @typeParam ComponentProps
  *   Props type.
@@ -49,12 +49,12 @@ export type ExtraProps = {node?: Element | undefined}
 /**
  * Possible components to use.
  *
- * Each key is a tag name typed in `LocalJsx.IntrinsicElements`.
+ * Each key is a tag name typed in `JsxIntrinsicElements`.
  * Each value is either a different tag name, or a component accepting the
  * corresponding props (and an optional `node` prop if `passNode` is on).
  *
- * You can access props at `LocalJsx.IntrinsicElements`.
- * For example, to find props for `a`, use `LocalJsx.IntrinsicElements['a']`.
+ * You can access props at `JsxIntrinsicElements`.
+ * For example, to find props for `a`, use `JsxIntrinsicElements['a']`.
  */
 // Note: this type has to be in `.ts` or `.d.ts`, otherwise TSC hardcodes
 // react into the `.d.ts` file.

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,45 +27,63 @@
  * @typedef {import('property-information').Schema} Schema
  *
  * @typedef {import('unist').Position} Position
- *
- * @typedef {import('./components.js').Components} Components
  */
 
 /**
- * @typedef {JSX.Element | string | null | undefined} Child
+ * @typedef {import('./components.js').Components<JsxElement, JsxElementClass, JsxIntrinsicElements>} Components
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
+ */
+
+/**
+ * @typedef {JsxElement | string | null | undefined} Child
  *   Child.
- *
+ * @template JsxElement
+ */
+
+/**
  * @callback Create
  *   Create something in development or production.
  * @param {Nodes} node
  *   hast node.
  * @param {unknown} type
  *   Fragment symbol or tag name.
- * @param {Props} props
+ * @param {Props<JsxElement>} props
  *   Properties and children.
  * @param {string | undefined} key
  *   Key.
- * @returns {JSX.Element}
+ * @returns {JsxElement}
  *   Result.
+ * @template JsxElement
+ */
+
+/**
  *
  * @callback CreateEvaluater
  *   Create an evaluator that turns ESTree ASTs from embedded MDX into values.
  * @returns {Evaluater}
  *   Evaluater.
- *
+ */
+
+/**
  * @typedef {'html' | 'react'} ElementAttributeNameCase
  *   Casing to use for attribute names.
  *
  *   HTML casing is for example `class`, `stroke-linecap`, `xml:lang`.
  *   React casing is for example `className`, `strokeLinecap`, `xmlLang`.
- *
+ */
+
+/**
  * @callback EvaluateExpression
  *   Turn an MDX expression into a value.
  * @param {Expression} expression
  *   ESTree expression.
  * @returns {unknown}
  *   Result of expression.
- *
+ */
+
+/**
  * @callback EvaluateProgram
  *   Turn an MDX program (export/import statements) into a value.
  * @param {Program} expression
@@ -74,36 +92,47 @@
  *   Result of program;
  *   should likely be `undefined` as ESM changes the scope but doesn’t yield
  *   something.
- *
+ */
+
+/**
  * @typedef Evaluater
  *   Evaluator that turns ESTree ASTs from embedded MDX into values.
  * @property {EvaluateExpression} evaluateExpression
  *   Evaluate an expression.
  * @property {EvaluateProgram} evaluateProgram
  *   Evaluate a program.
- *
+ */
+
+/**
  * @typedef {[string, Value]} Field
  *   Property field.
- *
+ */
+
+/**
  * @typedef {unknown} Fragment
  *   Represent the children, typically a symbol.
- *
+ */
+
+/**
  * @callback Jsx
  *   Create a production element.
  * @param {unknown} type
  *   Element type: `Fragment` symbol, tag name (`string`), component.
- * @param {Props} props
+ * @param {Props<JsxElement>} props
  *   Element props, `children`, and maybe `node`.
  * @param {string | undefined} [key]
  *   Dynamicly generated key to use.
- * @returns {JSX.Element}
+ * @returns {JsxElement}
  *   Element from your framework.
- *
+ * @template JsxElement
+ */
+
+/**
  * @callback JsxDev
  *   Create a development element.
  * @param {unknown} type
  *   Element type: `Fragment` symbol, tag name (`string`), component.
- * @param {Props} props
+ * @param {Props<JsxElement>} props
  *   Element props, `children`, and maybe `node`.
  * @param {string | undefined} key
  *   Dynamicly generated key to use.
@@ -114,15 +143,24 @@
  *   Info about source.
  * @param {undefined} self
  *   Nothing (this is used by frameworks that have components, we don’t).
- * @returns {JSX.Element}
+ * @returns {JsxElement}
  *   Element from your framework.
- *
- * @typedef {{children?: Array<Child> | Child, node?: Element | MdxJsxFlowElement | MdxJsxTextElement | undefined, [prop: string]: Array<Child> | Child | Element | MdxJsxFlowElement | MdxJsxTextElement | Value | undefined}} Props
+ * @template JsxElement
+ */
+
+/**
+ * @typedef {{children?: Array<Child<JsxElement>> | Child<JsxElement>, node?: Element | MdxJsxFlowElement | MdxJsxTextElement | undefined, [prop: string]: Array<Child<JsxElement>> | Child<JsxElement> | Element | MdxJsxFlowElement | MdxJsxTextElement | Value | undefined}} Props
  *   Properties and children.
- *
+ * @template JsxElement
+ */
+
+/**
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
  * @typedef RegularFields
  *   Configuration.
- * @property {Partial<Components> | null | undefined} [components]
+ * @property {Partial<Components<JsxElement, JsxElementClass, JsxIntrinsicElements>> | null | undefined} [components]
  *   Components to use (optional).
  * @property {CreateEvaluater | null | undefined} [createEvaluater]
  *   Create an evaluator that turns ESTree ASTs into values (optional).
@@ -154,46 +192,57 @@
  * @property {boolean | null | undefined} [tableCellAlignToStyle=true]
  *   Turn obsolete `align` props on `td` and `th` into CSS `style` props
  *   (default: `true`).
- *
+ */
+
+/**
+ * @template JsxElement
  * @typedef RuntimeDevelopment
  *   Runtime fields when development is on.
  * @property {Fragment} Fragment
  *   Fragment.
  * @property {true} development
  *   Whether to use `jsxDEV` (when on) or `jsx` and `jsxs` (when off).
- * @property {Jsx | null | undefined} [jsx]
+ * @property {Jsx<JsxElement> | null | undefined} [jsx]
  *   Dynamic JSX (optional).
- * @property {JsxDev} jsxDEV
+ * @property {JsxDev<JsxElement>} jsxDEV
  *   Development JSX.
- * @property {Jsx | null | undefined} [jsxs]
+ * @property {Jsx<JsxElement> | null | undefined} [jsxs]
  *   Static JSX (optional).
- *
+ */
+
+/**
+ * @template JsxElement
  * @typedef RuntimeProduction
  *   Runtime fields when development is off.
  * @property {Fragment} Fragment
  *   Fragment.
  * @property {false | null | undefined} [development]
  *   Whether to use `jsxDEV` (when on) or `jsx` and `jsxs` (when off) (optional).
- * @property {Jsx} jsx
+ * @property {Jsx<JsxElement>} jsx
  *   Dynamic JSX.
- * @property {JsxDev | null | undefined} [jsxDEV]
+ * @property {JsxDev<JsxElement> | null | undefined} [jsxDEV]
  *   Development JSX (optional).
- * @property {Jsx} jsxs
+ * @property {Jsx<JsxElement>} jsxs
  *   Static JSX.
- *
+ */
+
+/**
+ * @template JsxElement
  * @typedef RuntimeUnknown
  *   Runtime fields when development might be on or off.
  * @property {Fragment} Fragment
  *   Fragment.
  * @property {boolean} development
  *   Whether to use `jsxDEV` (when on) or `jsx` and `jsxs` (when off).
- * @property {Jsx | null | undefined} [jsx]
+ * @property {Jsx<JsxElement> | null | undefined} [jsx]
  *   Dynamic JSX (optional).
- * @property {JsxDev | null | undefined} [jsxDEV]
+ * @property {JsxDev<JsxElement> | null | undefined} [jsxDEV]
  *   Development JSX (optional).
- * @property {Jsx | null | undefined} [jsxs]
+ * @property {Jsx<JsxElement> | null | undefined} [jsxs]
  *   Static JSX (optional).
- *
+ */
+
+/**
  * @typedef Source
  *   Info about source.
  * @property {number | undefined} columnNumber
@@ -202,7 +251,9 @@
  *   Name of source file.
  * @property {number | undefined} lineNumber
  *   Line where thing starts (1-indexed).
- *
+ */
+
+/**
  * @typedef {'html' | 'svg'} Space
  *   Namespace.
  *
@@ -211,16 +262,21 @@
  *   > It does not support the features available in XML.
  *   > Passing SVG might break but fragments of modern SVG should be fine.
  *   > Use `xast` if you need to support SVG as XML.
- *
+ */
+
+/**
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
  * @typedef State
  *   Info passed around.
  * @property {unknown} Fragment
  *   Fragment symbol.
  * @property {Array<Parents>} ancestors
  *   Stack of parents.
- * @property {Partial<Components>} components
+ * @property {Partial<Components<JsxElement, JsxElementClass, JsxIntrinsicElements>>} components
  *   Components to swap.
- * @property {Create} create
+ * @property {Create<JsxElement>} create
  *   Create something in development or production.
  * @property {ElementAttributeNameCase} elementAttributeNameCase
  *   Casing to use for attribute names.
@@ -240,29 +296,56 @@
  *   Casing to use for property names in `style` objects.
  * @property {boolean} tableCellAlignToStyle
  *   Turn obsolete `align` props on `td` and `th` into CSS `style` props.
- *
+ */
+
+/**
  * @typedef {Record<string, string>} Style
  *   Style map.
- *
+ */
+
+/**
  * @typedef {'css' | 'dom'} StylePropertyNameCase
  *   Casing to use for property names in `style` objects.
  *
  *   CSS casing is for example `background-color` and `-webkit-line-clamp`.
  *   DOM casing is for example `backgroundColor` and `WebkitLineClamp`.
- *
+ */
+
+/**
  * @typedef {Style | boolean | number | string} Value
  *   Primitive property value and `Style` map.
  */
 
 /**
- * @typedef {RuntimeDevelopment & RegularFields} Development
+ * @typedef {RuntimeDevelopment<JsxElement> & RegularFields<JsxElement, JsxElementClass, JsxIntrinsicElements>} Development
  *   Configuration (development).
- * @typedef {Development | Production | Unknown} Options
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
+ */
+
+/**
+ * @typedef {Development<JsxElement, JsxElementClass, JsxIntrinsicElements> | Production<JsxElement, JsxElementClass, JsxIntrinsicElements> | Unknown<JsxElement, JsxElementClass, JsxIntrinsicElements>} Options
  *   Configuration.
- * @typedef {RegularFields & RuntimeProduction} Production
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
+ */
+
+/**
+ * @typedef {RegularFields<JsxElement, JsxElementClass, JsxIntrinsicElements> & RuntimeProduction<JsxElement>} Production
  *   Configuration (production).
- * @typedef {RegularFields & RuntimeUnknown} Unknown
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
+ */
+
+/**
+ * @typedef {RegularFields<JsxElement, JsxElementClass, JsxIntrinsicElements> & RuntimeUnknown<JsxElement>} Unknown
  *   Configuration (production or development).
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
  */
 
 import {stringify as commas} from 'comma-separated-tokens'
@@ -304,11 +387,14 @@ const docs = 'https://github.com/syntax-tree/hast-util-to-jsx-runtime'
  * Transform a hast tree to preact, react, solid, svelte, vue, etc.,
  * with an automatic JSX runtime.
  *
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
  * @param {Nodes} tree
  *   Tree to transform.
- * @param {Options} options
+ * @param {Options<JsxElement, JsxElementClass, JsxIntrinsicElements>} options
  *   Configuration (required).
- * @returns {JSX.Element}
+ * @returns {JsxElement}
  *   JSX element.
  */
 
@@ -318,7 +404,7 @@ export function toJsxRuntime(tree, options) {
   }
 
   const filePath = options.filePath || undefined
-  /** @type {Create} */
+  /** @type {Create<JsxElement>} */
   let create
 
   if (options.development) {
@@ -341,7 +427,7 @@ export function toJsxRuntime(tree, options) {
     create = productionCreate(filePath, options.jsx, options.jsxs)
   }
 
-  /** @type {State} */
+  /** @type {State<JsxElement, JsxElementClass, JsxIntrinsicElements>} */
   const state = {
     Fragment: options.Fragment,
     ancestors: [],
@@ -377,13 +463,16 @@ export function toJsxRuntime(tree, options) {
 /**
  * Transform a node.
  *
- * @param {State} state
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
+ * @param {State<JsxElement, JsxElementClass, JsxIntrinsicElements>} state
  *   Info passed around.
  * @param {Nodes} node
  *   Current node.
  * @param {string | undefined} key
  *   Key.
- * @returns {Child | undefined}
+ * @returns {Child<JsxElement> | undefined}
  *   Child, optional.
  */
 function one(state, node, key) {
@@ -415,13 +504,16 @@ function one(state, node, key) {
 /**
  * Handle element.
  *
- * @param {State} state
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
+ * @param {State<JsxElement, JsxElementClass, JsxIntrinsicElements>} state
  *   Info passed around.
  * @param {Element} node
  *   Current node.
  * @param {string | undefined} key
  *   Key.
- * @returns {Child | undefined}
+ * @returns {Child<JsxElement> | undefined}
  *   Child, optional.
  */
 function element(state, node, key) {
@@ -458,11 +550,14 @@ function element(state, node, key) {
 /**
  * Handle MDX expression.
  *
- * @param {State} state
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
+ * @param {State<JsxElement, JsxElementClass, JsxIntrinsicElements>} state
  *   Info passed around.
  * @param {MdxFlowExpression | MdxTextExpression} node
  *   Current node.
- * @returns {Child | undefined}
+ * @returns {Child<JsxElement> | undefined}
  *   Child, optional.
  */
 function mdxExpression(state, node) {
@@ -472,7 +567,7 @@ function mdxExpression(state, node) {
     assert(expression.type === 'ExpressionStatement')
 
     // Assume result is a child.
-    return /** @type {Child | undefined} */ (
+    return /** @type {Child<JsxElement> | undefined} */ (
       state.evaluater.evaluateExpression(expression.expression)
     )
   }
@@ -483,17 +578,20 @@ function mdxExpression(state, node) {
 /**
  * Handle MDX ESM.
  *
- * @param {State} state
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
+ * @param {State<JsxElement, JsxElementClass, JsxIntrinsicElements>} state
  *   Info passed around.
  * @param {MdxjsEsm} node
  *   Current node.
- * @returns {Child | undefined}
+ * @returns {Child<JsxElement> | undefined}
  *   Child, optional.
  */
 function mdxEsm(state, node) {
   if (node.data && node.data.estree && state.evaluater) {
     // Assume result is a child.
-    return /** @type {Child | undefined} */ (
+    return /** @type {Child<JsxElement> | undefined} */ (
       state.evaluater.evaluateProgram(node.data.estree)
     )
   }
@@ -504,13 +602,16 @@ function mdxEsm(state, node) {
 /**
  * Handle MDX JSX.
  *
- * @param {State} state
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
+ * @param {State<JsxElement, JsxElementClass, JsxIntrinsicElements>} state
  *   Info passed around.
  * @param {MdxJsxFlowElement | MdxJsxTextElement} node
  *   Current node.
  * @param {string | undefined} key
  *   Key.
- * @returns {Child | undefined}
+ * @returns {Child<JsxElement> | undefined}
  *   Child, optional.
  */
 function mdxJsxElement(state, node, key) {
@@ -544,17 +645,20 @@ function mdxJsxElement(state, node, key) {
 /**
  * Handle root.
  *
- * @param {State} state
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
+ * @param {State<JsxElement, JsxElementClass, JsxIntrinsicElements>} state
  *   Info passed around.
  * @param {Root} node
  *   Current node.
  * @param {string | undefined} key
  *   Key.
- * @returns {Child | undefined}
+ * @returns {Child<JsxElement> | undefined}
  *   Child, optional.
  */
 function root(state, node, key) {
-  /** @type {Props} */
+  /** @type {Props<JsxElement>} */
   const props = {}
 
   addChildren(props, createChildren(state, node))
@@ -565,11 +669,14 @@ function root(state, node, key) {
 /**
  * Handle text.
  *
- * @param {State} _
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
+ * @param {State<JsxElement, JsxElementClass, JsxIntrinsicElements>} _
  *   Info passed around.
  * @param {Text} node
  *   Current node.
- * @returns {Child | undefined}
+ * @returns {Child<JsxElement> | undefined}
  *   Child, optional.
  */
 function text(_, node) {
@@ -579,9 +686,12 @@ function text(_, node) {
 /**
  * Add `node` to props.
  *
- * @param {State} state
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
+ * @param {State<JsxElement, JsxElementClass, JsxIntrinsicElements>} state
  *   Info passed around.
- * @param {Props} props
+ * @param {Props<JsxElement>} props
  *   Props.
  * @param {unknown} type
  *   Type.
@@ -600,9 +710,10 @@ function addNode(state, props, type, node) {
 /**
  * Add children to props.
  *
- * @param {Props} props
+ * @template JsxElement
+ * @param {Props<JsxElement>} props
  *   Props.
- * @param {Array<Child>} children
+ * @param {Array<Child<JsxElement>>} children
  *   Children.
  * @returns {undefined}
  *   Nothing.
@@ -618,18 +729,19 @@ function addChildren(props, children) {
 }
 
 /**
+ * @template JsxElement
  * @param {string | undefined} _
  *   Path to file.
- * @param {Jsx} jsx
+ * @param {Jsx<JsxElement>} jsx
  *   Dynamic.
- * @param {Jsx} jsxs
+ * @param {Jsx<JsxElement>} jsxs
  *   Static.
- * @returns {Create}
+ * @returns {Create<JsxElement>}
  *   Create a production element.
  */
 function productionCreate(_, jsx, jsxs) {
   return create
-  /** @type {Create} */
+  /** @type {Create<JsxElement>} */
   function create(_, type, props, key) {
     // Only an array when there are 2 or more children.
     const isStaticChildren = Array.isArray(props.children)
@@ -639,16 +751,17 @@ function productionCreate(_, jsx, jsxs) {
 }
 
 /**
+ * @template JsxElement
  * @param {string | undefined} filePath
  *   Path to file.
- * @param {JsxDev} jsxDEV
+ * @param {JsxDev<JsxElement>} jsxDEV
  *   Development.
- * @returns {Create}
+ * @returns {Create<JsxElement>}
  *   Create a development element.
  */
 function developmentCreate(filePath, jsxDEV) {
   return create
-  /** @type {Create} */
+  /** @type {Create<JsxElement>} */
   function create(node, type, props, key) {
     // Only an array when there are 2 or more children.
     const isStaticChildren = Array.isArray(props.children)
@@ -671,15 +784,18 @@ function developmentCreate(filePath, jsxDEV) {
 /**
  * Create props from an element.
  *
- * @param {State} state
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
+ * @param {State<JsxElement, JsxElementClass, JsxIntrinsicElements>} state
  *   Info passed around.
  * @param {Element} node
  *   Current element.
- * @returns {Props}
+ * @returns {Props<JsxElement>}
  *   Props.
  */
 function createElementProps(state, node) {
-  /** @type {Props} */
+  /** @type {Props<JsxElement>} */
   const props = {}
   /** @type {string | undefined} */
   let alignValue
@@ -720,15 +836,18 @@ function createElementProps(state, node) {
 /**
  * Create props from a JSX element.
  *
- * @param {State} state
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
+ * @param {State<JsxElement, JsxElementClass, JsxIntrinsicElements>} state
  *   Info passed around.
  * @param {MdxJsxFlowElement | MdxJsxTextElement} node
  *   Current JSX element.
- * @returns {Props}
+ * @returns {Props<JsxElement>}
  *   Props.
  */
 function createJsxElementProps(state, node) {
-  /** @type {Props} */
+  /** @type {Props<JsxElement>} */
   const props = {}
 
   for (const attribute of node.attributes) {
@@ -773,7 +892,9 @@ function createJsxElementProps(state, node) {
       }
 
       // Assume a prop.
-      props[name] = /** @type {Props[keyof Props]} */ (value)
+      props[name] = /** @type {Props<JsxElement>[keyof Props<JsxElement>]} */ (
+        value
+      )
     }
   }
 
@@ -783,15 +904,18 @@ function createJsxElementProps(state, node) {
 /**
  * Create children.
  *
- * @param {State} state
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
+ * @param {State<JsxElement, JsxElementClass, JsxIntrinsicElements>} state
  *   Info passed around.
  * @param {Parents} node
  *   Current element.
- * @returns {Array<Child>}
+ * @returns {Array<Child<JsxElement>>}
  *   Children.
  */
 function createChildren(state, node) {
-  /** @type {Array<Child>} */
+  /** @type {Array<Child<JsxElement>>} */
   const children = []
   let index = -1
   /** @type {Map<string, number>} */
@@ -830,7 +954,10 @@ function createChildren(state, node) {
 /**
  * Handle a property.
  *
- * @param {State} state
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
+ * @param {State<JsxElement, JsxElementClass, JsxIntrinsicElements>} state
  *   Info passed around.
  * @param {string} prop
  *   Key.
@@ -880,7 +1007,10 @@ function createProperty(state, prop, value) {
 /**
  * Parse a CSS declaration to an object.
  *
- * @param {State} state
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
+ * @param {State<JsxElement, JsxElementClass, JsxIntrinsicElements>} state
  *   Info passed around.
  * @param {string} value
  *   CSS declarations.
@@ -939,7 +1069,10 @@ function parseStyle(state, value) {
 /**
  * Create a JSX name from a string.
  *
- * @param {State} state
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
+ * @param {State<JsxElement, JsxElementClass, JsxIntrinsicElements>} state
  *   To do.
  * @param {string} name
  *   Name.
@@ -988,7 +1121,7 @@ function findComponentFromName(state, name, allowExpression) {
   // Only literals can be passed in `components` currently.
   // No identifiers / member expressions.
   if (result.type === 'Literal') {
-    const name = /** @type {keyof JSX.IntrinsicElements} */ (result.value)
+    const name = /** @type {keyof JsxIntrinsicElements} */ (result.value)
 
     return own.call(state.components, name) ? state.components[name] : name
   }
@@ -1002,7 +1135,10 @@ function findComponentFromName(state, name, allowExpression) {
 }
 
 /**
- * @param {State} state
+ * @template JsxElement
+ * @template JsxElementClass
+ * @template JsxIntrinsicElements
+ * @param {State<JsxElement, JsxElementClass, JsxIntrinsicElements>} state
  * @param {Position | undefined} [place]
  * @returns {never}
  */

--- a/test/index.js
+++ b/test/index.js
@@ -1,13 +1,20 @@
 /**
- * @typedef {import('estree').Expression} Expression
  * @typedef {import('estree').Program} Program
  *
  * @typedef {import('hast-util-to-jsx-runtime').CreateEvaluater} CreateEvaluater
  * @typedef {import('hast-util-to-jsx-runtime').Fragment} Fragment
- * @typedef {import('hast-util-to-jsx-runtime').Jsx} Jsx
- * @typedef {import('hast-util-to-jsx-runtime').JsxDev} JsxDev
  *
  * @typedef {import('../lib/index.js').Source} Source
+ * @typedef {import('hast-util-to-jsx-runtime').Jsx<JsxElement>} Jsx
+ * @typedef {import('hast-util-to-jsx-runtime').JsxDev<JsxElement>} JsxDev
+ */
+
+/**
+ * @typedef {import('react').JSX.Element} JsxElement
+ */
+
+/**
+ * @typedef {import('react').JSX.IntrinsicElements} JsxIntrinsicElements
  */
 
 import assert from 'node:assert/strict'
@@ -17,24 +24,13 @@ import {h, s} from 'hastscript'
 import {toJsxRuntime} from 'hast-util-to-jsx-runtime'
 import * as sval from 'sval'
 import React from 'react'
-import * as dev from 'react/jsx-dev-runtime'
-import * as prod from 'react/jsx-runtime'
+import * as development from 'react/jsx-dev-runtime'
+import * as production from 'react/jsx-runtime'
 import {renderToStaticMarkup} from 'react-dom/server'
 
 /** @type {import('sval')['default']} */
 // @ts-expect-error: ESM types are wrong.
 const Sval = sval.default
-
-const production = /** @type {{Fragment: Fragment, jsx: Jsx, jsxs: Jsx}} */ ({
-  Fragment: prod.Fragment,
-  jsx: prod.jsx,
-  jsxs: prod.jsxs
-})
-
-const development = /** @type {{Fragment: Fragment, jsxDEV: JsxDev}} */ ({
-  Fragment: dev.Fragment,
-  jsxDEV: dev.jsxDEV
-})
 
 test('core', async function (t) {
   await t.test('should expose the public api', async function () {
@@ -491,7 +487,7 @@ test('source', async function (t) {
   })
 
   /**
-   * @param {JSX.Element} node
+   * @param {JsxElement} node
    * @returns {Source | undefined}
    */
   function getSource(node) {
@@ -528,7 +524,7 @@ test('components', async function (t) {
           components: {
             b: class extends React.Component {
               /**
-               * @param {JSX.IntrinsicElements['b']} props
+               * @param {JsxIntrinsicElements['b']} props
                */
               constructor(props) {
                 super(props)
@@ -591,6 +587,7 @@ test('components', async function (t) {
         toJsxRuntime(h('h1', 'a'), {
           ...production,
           passNode: true,
+          // @ts-expect-error: to do: investigate.
           components: {h1: 'h2'}
         })
       ),
@@ -842,6 +839,7 @@ test('mdx: jsx', async function (t) {
       renderToStaticMarkup(
         toJsxRuntime(
           {type: 'mdxJsxTextElement', name: 'a', attributes: [], children: []},
+          // @ts-expect-error: to do: investigate.
           {...production, components: {a: 'b'}}
         )
       ),

--- a/test/index.js
+++ b/test/index.js
@@ -587,7 +587,6 @@ test('components', async function (t) {
         toJsxRuntime(h('h1', 'a'), {
           ...production,
           passNode: true,
-          // @ts-expect-error: to do: investigate.
           components: {h1: 'h2'}
         })
       ),
@@ -839,7 +838,6 @@ test('mdx: jsx', async function (t) {
       renderToStaticMarkup(
         toJsxRuntime(
           {type: 'mdxJsxTextElement', name: 'a', attributes: [], children: []},
-          // @ts-expect-error: to do: investigate.
           {...production, components: {a: 'b'}}
         )
       ),


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Cleaner but completely broken version of what GH-6 attempts.
This does not remove functionality (components).
But because TS limitations (and likely that `jsx` types are not very good), we can’t infer some `IntrinsicElements` registry from a `jsx` function or an `Element` type.

<!--do not edit: pr-->
