### PR TITLE
Use style-to-js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ import {name as isIdentifierName} from 'estree-util-is-identifier-name'
 import {whitespace} from 'hast-util-whitespace'
 import {find, hastToReact, html, svg} from 'property-information'
 import {stringify as spaces} from 'space-separated-tokens'
-import styleToObject from 'style-to-object'
+import styleToJs from 'style-to-js'
 import {pointStart} from 'unist-util-position'
 import {VFileMessage} from 'vfile-message'
 
@@ -26,7 +26,6 @@ const own = {}.hasOwnProperty
 const emptyMap = new Map()
 
 const cap = /[A-Z]/g
-const dashSomething = /-([a-z])/g
 
 // `react-dom` triggers a warning for *any* white space in tables.
 // To follow GFM, `mdast-util-to-hast` injects line endings between elements.
@@ -635,11 +634,8 @@ function createProperty(state, prop, value) {
  *   Throws `VFileMessage` when CSS cannot be parsed.
  */
 function parseStyle(state, value) {
-  /** @type {Style} */
-  const result = {}
-
   try {
-    styleToObject(value, replacer)
+    return styleToJs(value, {reactCompat: true})
   } catch (error) {
     if (!state.ignoreInvalidStyle) {
       const cause = /** @type {Error} */ (error)
@@ -654,30 +650,6 @@ function parseStyle(state, value) {
 
       throw message
     }
-  }
-
-  return result
-
-  /**
-   * Add a CSS property (normal, so with dashes) to `result` as a DOM CSS
-   * property.
-   *
-   * @param {string} name
-   *   Key.
-   * @param {string} value
-   *   Value
-   * @returns {undefined}
-   *   Nothing.
-   */
-  function replacer(name, value) {
-    let key = name
-
-    if (key.slice(0, 2) !== '--') {
-      if (key.slice(0, 4) === '-ms-') key = 'ms-' + key.slice(4)
-      key = key.replace(dashSomething, toCamel)
-    }
-
-    result[key] = value
   }
 }
 
@@ -798,20 +770,6 @@ function transformStyleToCssCasing(from) {
   // Handle `ms-xxx` -> `-ms-xxx`.
   if (to.slice(0, 3) === 'ms-') to = '-' + to
   return to
-}
-
-/**
- * Make `$1` capitalized.
- *
- * @param {string} _
- *   Whatever.
- * @param {string} $1
- *   Single ASCII alphabetical.
- * @returns {string}
- *   Capitalized `$1`.
- */
-function toCamel(_, $1) {
-  return $1.toUpperCase()
 }
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -637,19 +637,21 @@ function parseStyle(state, value) {
   try {
     return styleToJs(value, {reactCompat: true})
   } catch (error) {
-    if (!state.ignoreInvalidStyle) {
-      const cause = /** @type {Error} */ (error)
-      const message = new VFileMessage('Cannot parse `style` attribute', {
-        ancestors: state.ancestors,
-        cause,
-        ruleId: 'style',
-        source: 'hast-util-to-jsx-runtime'
-      })
-      message.file = state.filePath || undefined
-      message.url = docs + '#cannot-parse-style-attribute'
-
-      throw message
+    if (state.ignoreInvalidStyle) {
+      return {}
     }
+
+    const cause = /** @type {Error} */ (error)
+    const message = new VFileMessage('Cannot parse `style` attribute', {
+      ancestors: state.ancestors,
+      cause,
+      ruleId: 'style',
+      source: 'hast-util-to-jsx-runtime'
+    })
+    message.file = state.filePath || undefined
+    message.url = docs + '#cannot-parse-style-attribute'
+
+    throw message
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "mdast-util-mdxjs-esm": "^2.0.0",
     "property-information": "^7.0.0",
     "space-separated-tokens": "^2.0.0",
-    "style-to-object": "^1.0.0",
+    "style-to-js": "^1.0.0",
     "unist-util-position": "^5.0.0",
     "vfile-message": "^4.0.0"
   },


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Asyntax-tree&type=issues and https://github.com/orgs/syntax-tree/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

`style-to-js` is a small wrapper around `style-to-object`. It’s maintained by the same person. It performs the same logic we had in here, meaning that dependency can replaces it.

This is the same as https://github.com/syntax-tree/hast-util-to-estree/pull/10

<!--do not edit: pr-->
